### PR TITLE
Fixed the Readme.md page error by renaming to README.md

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
 			<p>
 				Unfortunatelly, this function is not possible with static HTML+JS.
 				You must provided a plist generator URL.
-				See <a href="Readme.md" target="_blank">Readme</a> file for further instructions on how to set up such a
+				See <a href="README.md" target="_blank">Readme</a> file for further instructions on how to set up such a
 				service.
 			</p>
 			<form onsubmit="event.preventDefault(); setPlistGen(); return false;" autocomplete="off">


### PR DESCRIPTION
When you clicked on the See Readme file it would lead to an invalid page (https://stuffed18.github.io/ipa-archive-updated/Readme.md)