### PR TITLE
A fix for weird PNGs that aren't displaying properly

### DIFF
--- a/tools/fix_PNG_CgBI.py
+++ b/tools/fix_PNG_CgBI.py
@@ -1,0 +1,19 @@
+import glob
+import pyipng
+
+# Converts weird Apple PNG CgBI format to normal PNGs
+
+def fix_iPNG(file_path):        
+    try:
+        with open(file_path,'rb') as f:
+            bytes = f.read()
+            fix_bytes = pyipng.convert(bytes)
+            with open(file_path,'wb') as f:
+                f.write(fix_bytes)
+                print(f'{file_path} fixed')
+    except ValueError:
+        print(f'{file_path} doesn\'t need fixing')
+
+
+for file in glob.glob('../data/*/*.png'):
+    fix_iPNG(file)


### PR DESCRIPTION
Apple had its own non-standard PNG format ([PNG CgBI](https://theapplewiki.com/wiki/PNG_CgBI_Format)) that was used sometimes on early iPhones. I wrote a script (tools/fix_PNG_CgBI.py) that converts them to normal PNGs using [PyiPNG](https://github.com/venjye/PyiPNG/tree/master?tab=readme-ov-file) library. Still doesn't fix some of the icons for some reason (for example, 51990.png is fixable, but 50471.png isn't)